### PR TITLE
fixed admin page displaying the wrong week

### DIFF
--- a/website/static/admin.js
+++ b/website/static/admin.js
@@ -24,7 +24,7 @@ window.onload = function() {
     const days = Math.floor((today - startOfYear) / (24 * 60 * 60 * 1000));
     
     let weekNumber = Math.ceil((days + 1) / 7); // use let instead of const here
-    weekNumber += 1; // now this is allowed since weekNumber is declared with let
+    // weekNumber += 1; // now this is allowed since weekNumber is declared with let
 
     let nextWeekYear = year;
     if (weekNumber > 52) {


### PR DESCRIPTION
Commented out one line in the window.onload function in admin.js. It solved the problem, but if that line was important for some reason it may not be the actual bug.